### PR TITLE
PC-916: fix vulnerabilities in v0.6.x

### DIFF
--- a/src/PodiumdAdapter.Web/PodiumdAdapter.Web.csproj
+++ b/src/PodiumdAdapter.Web/PodiumdAdapter.Web.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
   </ItemGroup>

--- a/test/PodiumdAdapter.Web.Test/PodiumdAdapter.Web.Test.csproj
+++ b/test/PodiumdAdapter.Web.Test/PodiumdAdapter.Web.Test.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="Verify.Xunit" Version="23.1.0" />


### PR DESCRIPTION
# Updates
| dependency | detected by | new version  | breaking change | 
|----------:|--:|--:|--:|
|      `Serilog.AspNetCore`     | Snyk | 8.0.3  |   | 
|      `Microsoft.AspNetCore.Mvc.Testing`  | Snyk | 8.0.13  |   |  

# Focus for testing
No testing necessary